### PR TITLE
Fix typo in main.py comment

### DIFF
--- a/main.py
+++ b/main.py
@@ -271,7 +271,7 @@ def detect_container_details(input_image_byte: bytes) -> json:
     # Analyze and get results
     result: sdk.ImageAnalysisResult = image_analyzer.analyze()
 
-    # Early exist if error
+    # Early exit if error
     cnrai_detection: CNRAI = CNRAI()
     if result.reason != sdk.ImageAnalysisResultReason.ANALYZED:
         error_details = sdk.ImageAnalysisErrorDetails.from_result(result)


### PR DESCRIPTION
## Summary
- fix 'Early exit' typo in comment next to `image_analyzer.analyze`

## Testing
- `git status --short`